### PR TITLE
Reuse Audio Element to fix Safari Issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,9 @@
 			<!-- ip display -->
 			<h1><font size="6">Your IP is:</font> <script type="text/javascript">document.write(ip);</script></h1>
 			
+			<!-- audio element -->
+			<audio id="playitagain"></audio>
+			
 			<!-- some info -->
 			<p class="lead">Just click the button below to hear your IP address in the most dumb way possible. I promise, it will be stupid...</p>
 			

--- a/js/saymyip.js
+++ b/js/saymyip.js
@@ -7,6 +7,7 @@
 var img1 = "img/special.png";
 var img2 = "img/special2.png";
 var imgElement = "awesome"; // The element id for the title image.
+var audioElement = "playitagain";
 var titleSound = "sounds/duh.mp3";
 var dir = "sounds/"; // The directory of all the audio clips.
 var ext = ".mp3";
@@ -35,7 +36,7 @@ function main(json)
 		sounds[i.toString()] = new Array(); 
 		for (var j = 1; j <= takes; j++) // Add random sounds 1 - 3 for this digit
 		{
-			sounds[i.toString()][j] = new Audio(dir + i + "-" + j + ext);
+			sounds[i.toString()][j] = dir + i + "-" + j + ext;
 		}	
 	}
 	
@@ -46,10 +47,20 @@ function main(json)
 
 	for (var i = 1; i <= takes; i++)
 	{
-		sounds['.'][i] = new Audio(dir + "dot-" + i + ext);
-		sounds['starting'][i] = new Audio(dir + "starting-" + i + ext);
-		sounds['ending'][i] = new Audio(dir + "ending-" + i + ext);
+		sounds['.'][i] = dir + "dot-" + i + ext;
+		sounds['starting'][i] = dir + "starting-" + i + ext;
+		sounds['ending'][i] = dir + "ending-" + i + ext;
 	}
+}
+
+function playAudio(src, onend)
+{
+	var audio = document.getElementById(audioElement);
+	audio.src = src;
+	audio.play();
+	audio.onended = function() {
+		onend();
+	};
 }
 
 /*
@@ -74,13 +85,7 @@ function playIP(i)
 	else // Else we're just strolling through the middle of the IP.
 		curSound = sounds[ip.charAt(i)][rand];
 	
-	// Play the current character!
-	curSound.play();
-	
-	// Now we wait. Don't play the next sound until the current one is finished.
-	curSound.onended = function() {
-    	playIP(++i);
-	};
+	playAudio(curSound, playIP.bind(null, i+1));
 }
 
 /*
@@ -102,17 +107,7 @@ function playTitleSound()
 		
 	switchImg(true);
 	
-	// Create temp var to hold the sound.
-	var title = new Audio(titleSound);
-	
-	// Play the sound.
-	title.play();
-	
-	// Wait until the sound is done then switch the image back.
-	title.onended = function() {
-    	switchImg(false);
-	};
-	
+	playAudio(titleSound, switchImg.bind(null, false));
 }
 
 /*


### PR DESCRIPTION
This fixes #32. When you try to play an audio element from Javascript, Safari tries to determine if it was due to a user interaction or not. The idea is to prevent auto-play elements from annoying the user (or something). Since the first sound is played from a callback of a button press, it allows that sound to play. However, it doesn't see the next sound clip as also being from the same button press, so it gets blocked.

According to [Apple's documentation](https://developer.apple.com/library/content/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/ControllingMediaWithJavaScript/ControllingMediaWithJavaScript.html#//apple_ref/doc/uid/TP40009523-CH3-SW5), they want you to use a single audio element, and change its source, instead of creating multiple audio elements for each source. Changing this allows the audio to play as intended. This was also tested in Chrome and Firefox, and they still work.